### PR TITLE
fix: update ldflags to include version and enhance flag usage display

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{ .Version }}
 archives:
   - builds:
       - ikube

--- a/main.go
+++ b/main.go
@@ -7,13 +7,19 @@ import (
 	"strings"
 )
 
-var version = "0.1.2"
+var version = "dev"
 
 func parseFlags() (string, appConfig) {
 	var config appConfig
 	flag.CommandLine.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage:\n  ikube [flags] [filter]\n\n")
-		flag.PrintDefaults()
+		flag.VisitAll(func(f *flag.Flag) {
+			prefix := "-"
+			if len(f.Name) > 1 {
+				prefix = "--"
+			}
+			fmt.Fprintf(flag.CommandLine.Output(), "  %s%s\t%s\n", prefix, f.Name, f.Usage)
+		})
 	}
 	verbose := flag.Bool("v", false, "verbose mode")
 	temp := flag.Bool("l", false, "load kubeconfig in temporary shell")


### PR DESCRIPTION
This pull request updates how the application's version is set and improves the CLI usage output for better user experience. It introduces dynamic version injection during the build process and makes the help message for command-line flags clearer.

**Build and Versioning Improvements:**

* Updated the `ldflags` in `.goreleaser.yml` to inject the version at build time using `-X main.version={{ .Version }}`. This allows the built binary to reflect the actual release version instead of a hardcoded value.
* Changed the default value of the `version` variable in `main.go` to `"dev"`, so the value can be replaced during the build process.

**CLI Usability:**

* Enhanced the custom usage output for command-line flags in `main.go` to display single-character flags with a single dash (`-`) and multi-character flags with double dashes (`--`), making the help output more user-friendly and consistent with common CLI conventions.