### PR TITLE
fix: handle nil cluster in handleListSecrets to prevent panic

### DIFF
--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -257,9 +257,14 @@ func handleListSecrets(client infisical.InfisicalClientInterface, projectID stri
 				clusterName := secrets[i].SecretKey
 				cluster := kubeCfg.Clusters[clusterName]
 
+				server := ""
+				if cluster != nil {
+					server = cluster.Server
+				}
+
 				return fmt.Sprintf("Cluster: %s\nServer: %s\nComment: %s",
 					clusterName,
-					cluster.Server,
+					server,
 					secrets[i].SecretComment)
 			}),
 		)


### PR DESCRIPTION
This pull request makes a small but important change to how cluster information is displayed in the `handleListSecrets` function in `kubeconfig.go`. The update ensures that if a cluster is not found in the configuration, the code will not cause a runtime error by trying to access a property on a `nil` value.

- Error handling improvement:
  * In `handleListSecrets`, added a check to ensure `cluster` is not `nil` before accessing its `Server` property, preventing a possible nil pointer dereference. If `cluster` is `nil`, `server` is set to an empty string.