### PR TITLE
fix: handle nil cluster in kubeconfig deletion to prevent nil pointer…

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -70,9 +70,14 @@ func handleDeleteKubeconfigs(client infisical.InfisicalClientInterface, projectI
 			clusterName := secrets[i].SecretKey
 			cluster := kubeCfg.Clusters[clusterName]
 
+			server := ""
+			if cluster != nil {
+				server = cluster.Server
+			}
+
 			return fmt.Sprintf("Cluster: %s\nServer: %s\nComment: %s",
 				clusterName,
-				cluster.Server,
+				server,
 				secrets[i].SecretComment)
 		}),
 	)


### PR DESCRIPTION
This pull request makes a small update to the `handleDeleteKubeconfigs` function in `delete.go` to improve robustness when displaying cluster information. The change ensures that the code safely handles cases where a cluster may not be found in the kubeconfig.

- Prevents a potential nil pointer dereference by checking if `cluster` is non-nil before accessing its `Server` field and defaults to an empty string if not found.