### PR TITLE
Fix/misc

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -89,14 +89,14 @@ func promptForCredentials() (string, string, bool, error) {
 	return clientID, clientSecret, false, nil
 }
 
-func authenticateInfisical(config appConfig) (infisical.InfisicalClientInterface, error) {
+func authenticateInfisical(ctx context.Context, config appConfig) (infisical.InfisicalClientInterface, error) {
 	// First attempt with stored or env credentials
 	clientID, clientSecret, isFromKeyring, err := getCredentials(false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %v", err)
 	}
 
-	client := infisical.NewInfisicalClient(context.Background(), infisical.Config{
+	client := infisical.NewInfisicalClient(ctx, infisical.Config{
 		SiteUrl:          fmt.Sprintf("https://%s", config.infisicalServer),
 		AutoTokenRefresh: true,
 	})
@@ -131,7 +131,7 @@ func authenticateInfisical(config appConfig) (infisical.InfisicalClientInterface
 			return nil, fmt.Errorf("failed to get credentials: %v", err)
 		}
 
-		client = infisical.NewInfisicalClient(context.Background(), infisical.Config{
+		client = infisical.NewInfisicalClient(ctx, infisical.Config{
 			SiteUrl:          fmt.Sprintf("https://%s", config.infisicalServer),
 			AutoTokenRefresh: true,
 		})

--- a/auth.go
+++ b/auth.go
@@ -11,6 +11,14 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
+type credentialSource int
+
+const (
+	credentialSourceKeyring credentialSource = iota
+	credentialSourceEnv
+	credentialSourcePrompt
+)
+
 // clearStoredCredentials removes credentials from keyring
 func clearStoredCredentials() {
 	_ = keyring.Delete(keyringService, clientIDKey)
@@ -32,15 +40,15 @@ func storeCredentials(clientID, clientSecret string) error {
 	return nil
 }
 
-func getCredentials(forcePrompt bool) (string, string, bool, error) {
+func getCredentials(forcePrompt bool) (string, string, credentialSource, error) {
 	if !forcePrompt {
 		// First try environment variables
 		clientID := os.Getenv("INFISICAL_CLIENT_ID")
 		clientSecret := os.Getenv("INFISICAL_CLIENT_SECRET")
 
-		// If both are set in env vars, use them
+		// If both are set in env vars, use them without persisting to keyring
 		if clientID != "" && clientSecret != "" {
-			return clientID, clientSecret, false, nil
+			return clientID, clientSecret, credentialSourceEnv, nil
 		}
 
 		// Try to get from keyring
@@ -48,20 +56,20 @@ func getCredentials(forcePrompt bool) (string, string, bool, error) {
 		if clientID == "" {
 			clientID, err = keyring.Get(keyringService, clientIDKey)
 			if err != nil && err != keyring.ErrNotFound {
-				return "", "", false, fmt.Errorf("failed to get client ID from keyring: %v", err)
+				return "", "", credentialSourcePrompt, fmt.Errorf("failed to get client ID from keyring: %v", err)
 			}
 		}
 
 		if clientSecret == "" {
 			clientSecret, err = keyring.Get(keyringService, clientSecretKey)
 			if err != nil && err != keyring.ErrNotFound {
-				return "", "", false, fmt.Errorf("failed to get client secret from keyring: %v", err)
+				return "", "", credentialSourcePrompt, fmt.Errorf("failed to get client secret from keyring: %v", err)
 			}
 		}
 
 		// If we found both in keyring, return them
 		if clientID != "" && clientSecret != "" {
-			return clientID, clientSecret, true, nil
+			return clientID, clientSecret, credentialSourceKeyring, nil
 		}
 	}
 
@@ -69,29 +77,29 @@ func getCredentials(forcePrompt bool) (string, string, bool, error) {
 	return promptForCredentials()
 }
 
-func promptForCredentials() (string, string, bool, error) {
+func promptForCredentials() (string, string, credentialSource, error) {
 	reader := bufio.NewReader(os.Stdin)
 
 	fmt.Print("Enter Infisical Client ID: ")
 	clientID, err := reader.ReadString('\n')
 	if err != nil {
-		return "", "", false, fmt.Errorf("failed to read client ID: %v", err)
+		return "", "", credentialSourcePrompt, fmt.Errorf("failed to read client ID: %v", err)
 	}
 	clientID = strings.TrimSpace(clientID)
 
 	fmt.Print("Enter Infisical Client Secret: ")
 	clientSecret, err := reader.ReadString('\n')
 	if err != nil {
-		return "", "", false, fmt.Errorf("failed to read client secret: %v", err)
+		return "", "", credentialSourcePrompt, fmt.Errorf("failed to read client secret: %v", err)
 	}
 	clientSecret = strings.TrimSpace(clientSecret)
 
-	return clientID, clientSecret, false, nil
+	return clientID, clientSecret, credentialSourcePrompt, nil
 }
 
 func authenticateInfisical(ctx context.Context, config appConfig) (infisical.InfisicalClientInterface, error) {
 	// First attempt with stored or env credentials
-	clientID, clientSecret, isFromKeyring, err := getCredentials(false)
+	clientID, clientSecret, source, err := getCredentials(false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %v", err)
 	}
@@ -103,8 +111,8 @@ func authenticateInfisical(ctx context.Context, config appConfig) (infisical.Inf
 
 	_, err = client.Auth().UniversalAuthLogin(clientID, clientSecret)
 	if err == nil {
-		// If credentials were manually entered and valid, store them
-		if !isFromKeyring {
+		// Only persist credentials that were manually entered; env vars are intentionally transient
+		if source == credentialSourcePrompt {
 			if err := storeCredentials(clientID, clientSecret); err != nil {
 				if config.verbose {
 					fmt.Printf("Warning: Failed to store credentials: %v\n", err)
@@ -117,7 +125,7 @@ func authenticateInfisical(ctx context.Context, config appConfig) (infisical.Inf
 	}
 
 	// If credentials were from keyring and invalid, clear them and try once more
-	if isFromKeyring {
+	if source == credentialSourceKeyring {
 		if config.verbose {
 			fmt.Printf("Stored credentials are invalid: %v\n", err)
 		} else {
@@ -138,7 +146,7 @@ func authenticateInfisical(ctx context.Context, config appConfig) (infisical.Inf
 
 		_, err = client.Auth().UniversalAuthLogin(clientID, clientSecret)
 		if err == nil {
-			// Store the valid credentials
+			// Store the valid credentials entered by the user
 			if err := storeCredentials(clientID, clientSecret); err != nil {
 				if config.verbose {
 					fmt.Printf("Warning: Failed to store credentials: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 )
 
 var version = "dev"
@@ -50,6 +53,10 @@ func main() {
 	// Parse command line flags
 	filter, config := parseFlags()
 
+	// Create a context that is cancelled on SIGINT/SIGTERM
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	// Get Infisical server from environment variable
 	config.infisicalServer = os.Getenv("INFISICAL_SERVER")
 	if config.infisicalServer == "" {
@@ -64,7 +71,7 @@ func main() {
 	}
 
 	// Authenticate with Infisical
-	client, err := authenticateInfisical(config)
+	client, err := authenticateInfisical(ctx, config)
 	if err != nil {
 		if config.verbose {
 			fmt.Printf("Failed to authenticate: %v\n", err)

--- a/shell.go
+++ b/shell.go
@@ -47,8 +47,10 @@ func createTempKubeconfig(content []byte) (string, error) {
 		return "", fmt.Errorf("failed to create temporary file: %v", err)
 	}
 
-	// Write content
-	if err := os.WriteFile(tmpfile.Name(), content, 0600); err != nil {
+	defer tmpfile.Close()
+
+	// Write content directly to the open file descriptor to avoid TOCTOU
+	if _, err := tmpfile.Write(content); err != nil {
 		os.Remove(tmpfile.Name())
 		return "", fmt.Errorf("failed to write temporary file: %v", err)
 	}


### PR DESCRIPTION
This pull request refactors the authentication flow to better handle credential sources and improves process signal handling. The main changes include introducing a `credentialSource` type to track where credentials come from, updating the authentication logic to use this type, and ensuring the application responds gracefully to termination signals.

Authentication flow improvements:
* Introduced a `credentialSource` type and constants to explicitly track whether credentials are sourced from environment variables, keyring, or user prompt. (`auth.go`)
* Refactored `getCredentials` and related functions to return the credential source, and updated logic to only persist credentials when entered by the user, not when sourced from environment variables. (`auth.go`)
* Updated authentication retry logic to use the new `credentialSource` type for clearer and safer handling of invalid credentials. (`auth.go`) [[1]](diffhunk://#diff-1f48700829d7e0cdba7f3729d6a7c1c5df3aa11f2aeeed583c7e1e39aa7b66d1L120-R128) [[2]](diffhunk://#diff-1f48700829d7e0cdba7f3729d6a7c1c5df3aa11f2aeeed583c7e1e39aa7b66d1L134-R149)

Process and context management:
* Added context cancellation on SIGINT/SIGTERM using `signal.NotifyContext`, and passed this context throughout the application for safer shutdowns. (`main.go`) [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R4-R10) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R56-R59) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L67-R74)

File handling improvement:
* Modified temporary kubeconfig file creation to write directly to the open file descriptor, reducing the risk of TOCTOU (Time-of-check to time-of-use) vulnerabilities. (`shell.go`)